### PR TITLE
bug(SingleHeroPage): added access to heroes data in global context an…

### DIFF
--- a/src/pages/Hero.js
+++ b/src/pages/Hero.js
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useContext } from 'react';
 import { useParams } from 'react-router-dom';
 import { FaStar, FaRegStar } from 'react-icons/fa';
+import { GlobalContext } from '../context/GlobalContext';
 
 const powers = [
   'super strength',
@@ -11,6 +12,7 @@ const powers = [
 ];
 
 const HeroPage = () => {
+  const { heroes, updateFeatured } = useContext(GlobalContext);
   let { heroId } = useParams();
   const [hero, setHero] = useState({
     superhero: '',
@@ -22,12 +24,12 @@ const HeroPage = () => {
     image_url: '',
   });
 
-  /* TODO: Uncomment useEffect after heroes data set is hooked in */
-  // useEffect(() => {
-  //   let foundHero = heroes.find(h => h.id === +heroId);
-  //   // console.log(foundHero);
-  //   setHero(foundHero);
-  // }, [hero, heroId, heroes]);
+ 
+  useEffect(() => {
+    let foundHero = heroes.find(h => h.id === +heroId);
+   // console.log(foundHero);
+     setHero(foundHero);
+   }, [hero, heroId, heroes]);
 
   if (!hero.id) {
     return (
@@ -58,7 +60,7 @@ const HeroPage = () => {
                   <div className='th-card-header d-flex justify-content-between'>
                     <span>
                       <a
-                        // onClick={() => updateFeatured(hero.id)}
+                        onClick={() => updateFeatured(hero.id)}
                         href='javascript:void(0)'>
                         {hero.featured ? (
                           <FaStar style={{ color: 'gold' }} />


### PR DESCRIPTION
**When you open your pull requests, remove the lines that start and end with underscores (\_)**

## Changes

When navigating to single hero page, no hero is showing up

Relevant Context
Hero page needs access to heroes data in global context and updateFeatured functionality. Take a look at the component to see what needs to be added in.

1. Hero page has access to the heroes data in the global context
2. uncommented the updateFeatured onClick 

## Purpose

When navigating to single hero page,  hero is now showing up.



### Closes #11
